### PR TITLE
Rename the code block in the VersoProofFlow genre to lean

### DIFF
--- a/verso-genre/VersoProofFlow.lean
+++ b/verso-genre/VersoProofFlow.lean
@@ -17,9 +17,9 @@ structure Block where
   name : Name
   id : String
 
-def VersoProofFlow.Block.code : Block where
-  name := `VersoProofFlow.Block.code
-  id := "code"
+def VersoProofFlow.Block.lean : Block where
+  name := `VersoProofFlow.Block.lean
+  id := "lean"
 
 def parserInputString [Monad m] [MonadFileMap m] (str : TSyntax `str) : m String := do
   let preString := (← getFileMap).source.extract 0 (str.raw.getPos?.getD 0)
@@ -34,8 +34,8 @@ def parserInputString [Monad m] [MonadFileMap m] (str : TSyntax `str) : m String
   code := code ++ str.getString
   return code
 
-@[code_block_expander code]
-def code : CodeBlockExpander
+@[code_block_expander lean]
+def lean : CodeBlockExpander
   | _, str => do
     let altStr ← parserInputString str
 

--- a/verso-genre/VersoProofFlow/Demo.lean
+++ b/verso-genre/VersoProofFlow/Demo.lean
@@ -11,7 +11,7 @@ set_option pp.rawOnError true
 
 
 
-```code
+```lean
 theorem five_eq_5 : five = 5 := by
   -- !! begin solution
   skip; skip


### PR DESCRIPTION
Just to be more in line with the other files, might make more sense to keep the convention of ` ```lean`, just like ` ```coq`

I havent tested this on my side yet since my PC doesn't have lean installed, but its just a simple rename