### PR TITLE
Markdown plugin bug fix

### DIFF
--- a/src/ProofFlow/commands/insert-commands.ts
+++ b/src/ProofFlow/commands/insert-commands.ts
@@ -13,7 +13,7 @@ import {
 } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { GetPos } from "../CodeMirror/types.ts";
-import { CodeMirrorView } from "../CodeMirror/index.ts";
+import { CodeMirrorView } from "../codemirror/index.ts";
 import {
   collapsibleContentType,
   collapsibleNodeType,

--- a/src/ProofFlow/styles/ProofFlow.css
+++ b/src/ProofFlow/styles/ProofFlow.css
@@ -316,7 +316,7 @@
   .ProseMirror h4:first-child,
   .ProseMirror h5:first-child,
   .ProseMirror h6:first-child {
-    margin-top: 10px;
+    padding-top: 10px;
   }
   
   .ProseMirror {
@@ -325,5 +325,12 @@
     outline: none;
   }
   
-  .ProseMirror p { margin-bottom: 1em }
+  .ProseMirror p { padding-bottom: 1em }
   
+  p {
+    padding-block-start: 1em;
+    padding-block-end: 1em;
+    padding-inline-start: 0px;
+    padding-inline-end: 0px;
+    margin: 0px;
+  }


### PR DESCRIPTION
Fixed empty markdown cell programmatically getting a space inserted when clicked ("file should not change when user makes no changes")