### PR TITLE
ADD: ProofFlow now uses MV format by default.

### DIFF
--- a/src/ProofFlow/editor/ButtonBar.ts
+++ b/src/ProofFlow/editor/ButtonBar.ts
@@ -198,7 +198,10 @@ export class ButtonBar {
       },
       {
         symbol: "&#x21bb;",
-        cmd: () => proofFlow.reset(),
+        cmd: () => {
+          proofFlow.reset();
+          proofFlow.setFileName("file.mv");
+        },
         hoverText: "Clear File",
       },
       {

--- a/src/ProofFlow/editor/ProofFlow.ts
+++ b/src/ProofFlow/editor/ProofFlow.ts
@@ -33,13 +33,15 @@ import {
 
 import { Parser, SimpleParser } from "../parser/parser.ts";
 import {
-  CoqMDOutput,
   CoqMDParser,
-  CoqOutput,
   CoqParser,
-  LeanOutput,
   LeanParser,
 } from "../parser/parsers.ts";
+import {
+  CoqMDOutput,
+  CoqOutput,
+  LeanOutput,
+} from "../parser/outputconfigs.ts"
 import { LSPClientHandler } from "../lspClient/lspClientHandler.ts";
 import { DiagnosticsMessageData } from "../lspClient/models.ts";
 import {
@@ -75,7 +77,7 @@ export class ProofFlow {
   private fileSaver?: ProofFlowSaver;
 
   private userMode: UserMode = UserMode.Student; // The teacher mode of the editor
-  public fileName: string = "file.txt";
+  public fileName: string = "file.mv";
 
   // static filePath: string = "file.text";
   private fileType: AcceptedFileType = AcceptedFileType.Unknown;

--- a/src/ProofFlow/editor/ProofFlowDocument.ts
+++ b/src/ProofFlow/editor/ProofFlowDocument.ts
@@ -1,4 +1,5 @@
 import { Node } from "prosemirror-model";
+import { CoqMDOutput } from "../parser/outputconfigs";
 
 export {
   AreaType,
@@ -186,7 +187,7 @@ const NOPConfig: OutputConfig = {
 //TODO: Incorporate handling the index mapping here, this is a big task and should be done carefully.
 class ProofFlowDocument {
   areas: Area[];
-  private _outputConfig: OutputConfig = NOPConfig;
+  private _outputConfig: OutputConfig = CoqMDOutput;
 
   constructor(areas: Area[]) {
     this.areas = areas;

--- a/src/ProofFlow/parser/outputconfigs.ts
+++ b/src/ProofFlow/parser/outputconfigs.ts
@@ -1,0 +1,34 @@
+import { OutputConfig } from "../editor/ProofFlowDocument";
+
+export {
+  CoqOutput,
+  CoqMDOutput,
+  LeanOutput,
+}
+
+const CoqOutput: OutputConfig = {
+  text: ["(**", "*)"],
+  code: ["", ""],
+  math: ["$$", "$$"],
+  collapsible: ["<hint>", "</hint>"],
+  collapsibletitle: ['<hint title="TITLE">\n', "\n</hint>"],
+  input: ["<input-area>\n", "\n</input-area>"],
+};
+  
+const CoqMDOutput: OutputConfig = {
+  text: ["", ""],
+  code: ["\n```coq\n", "\n```"],
+  math: ["$$", "$$"],
+  collapsible: ["<hint>", "\n</hint>"],
+  collapsibletitle: ['<hint title="TITLE">', "\n</hint>"],
+  input: ["<input-area>", "\n</input-area>"],
+};
+
+const LeanOutput: OutputConfig = {
+  text: ["", ""],
+  code: ["```lean\n", "```\n"],
+  math: [":::math\n", ":::\n"],
+  collapsible: [":::collapsible\n", ":::\n"],
+  collapsibletitle: [":::collapsible\n# TITLE\n", ":::\n"],
+  input: [":::input\n", ":::\n"],
+};

--- a/src/ProofFlow/parser/parsers.ts
+++ b/src/ProofFlow/parser/parsers.ts
@@ -1,13 +1,9 @@
-import { OutputConfig } from "../editor/ProofFlowDocument";
 import { SimpleParser } from "./parser";
 
 export {
   CoqParser,
   CoqMDParser,
   LeanParser,
-  CoqOutput,
-  CoqMDOutput,
-  LeanOutput,
 };
 
 const CoqParser = new SimpleParser({
@@ -30,30 +26,3 @@ const LeanParser = new SimpleParser({
   collapsible: [/:::collapsible\n(?:# (.*?)\n)?/, /:::\n/],
   input: [/:::input\n/, /:::\n/],
 });
-
-const CoqOutput: OutputConfig = {
-  text: ["(**", "*)"],
-  code: ["", ""],
-  math: ["$$", "$$"],
-  collapsible: ["<hint>", "</hint>"],
-  collapsibletitle: ['<hint title="TITLE">\n', "\n</hint>"],
-  input: ["<input-area>\n", "\n</input-area>"],
-};
-
-const CoqMDOutput: OutputConfig = {
-  text: ["", ""],
-  code: ["\n```coq\n", "\n```"],
-  math: ["$$", "$$"],
-  collapsible: ["<hint>", "\n</hint>"],
-  collapsibletitle: ['<hint title="TITLE">', "\n</hint>"],
-  input: ["<input-area>", "\n</input-area>"],
-};
-
-const LeanOutput: OutputConfig = {
-  text: ["", ""],
-  code: ["```lean\n", "```\n"],
-  math: [":::math\n", ":::\n"],
-  collapsible: [":::collapsible\n", ":::\n"],
-  collapsibletitle: [":::collapsible\n# TITLE\n", ":::\n"],
-  input: [":::input\n", ":::\n"],
-};


### PR DESCRIPTION
Outputconfigs had to be moved because otherwise there was a dependency loop.

This is needed because in the first test case in the ATP we need to show that we can create a file.