### PR TITLE
Sync the PF document with vscode

### DIFF
--- a/src/ProofFlow/fileHandlers/vscodeSaver.ts
+++ b/src/ProofFlow/fileHandlers/vscodeSaver.ts
@@ -2,15 +2,10 @@ export { VSCodeSaver };
 import { ProofFlow } from "../editor/ProofFlow";
 import { vscode } from "../extension/vscode";
 import { ProofFlowSaver } from "./proofFlowSaver";
-
+import { AcceptedFileType } from "../parser/accepted-file-types";
 class VSCodeSaver implements ProofFlowSaver {
   constructor() {
-    window.addEventListener("message", (event) => {
-      const message = event.data;
-      if (message.command === "openFile") {
-        console.log("File opened: " + message.content);
-      }
-    });
+
   }
 
   save(pf: ProofFlow): void {
@@ -21,4 +16,32 @@ class VSCodeSaver implements ProofFlowSaver {
       text: "Saving file...",
     });
   }
+
+  // Make sure the proofflow document is synced with VSCode,
+  // so the state can be restored when accidentally closed by the user
+  syncPfDoc(pf: ProofFlow) {   
+    sync(pf);
+    addLoadFileListener(pf);
+  }
+
+
+}
+
+function sync(pf: ProofFlow) {
+  vscode.postMessage({
+    command: "syncFile",
+    content: pf.pfDocument.toString(),
+    text: pf.fileName,
+  });
+  setTimeout(sync, 1000, pf);
+  
+}
+
+function addLoadFileListener(pf: ProofFlow) {
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message.command === "loadFile") {
+      pf.openFile(message.content, message.text.split('.').pop() as AcceptedFileType);
+    }
+  });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,14 +34,9 @@ export let firefoxUsed =
   navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
 
 // Check if we are in a VSCode Extension Environment; base filesaver on that
-let fileSaver: ProofFlowSaver;
-if (vscode.isVSCodeEnvironment()) {
-  console.log("Running in VSCode Extension Environment");
-  fileSaver = new VSCodeSaver();
-} else {
-  console.log("Running in Web Application Environment");
-  fileSaver = new WebApplicationSaver();
-}
+let fileSaver: any; // Need any type to be able to call syncPfDoc for the VSCodeSaver
+let inVSCode = vscode.isVSCodeEnvironment();
+fileSaver = inVSCode ? new VSCodeSaver() : new WebApplicationSaver(); 
 
 // Create a new instance of the ProofFlow class
 let proofFlow: ProofFlow = new ProofFlow({
@@ -53,6 +48,9 @@ let proofFlow: ProofFlow = new ProofFlow({
     window.localStorage,
   ),
 });
+
+// Sync the PF document with VSCode (if we are in VSCode)
+if (inVSCode) fileSaver.syncPfDoc(proofFlow);
 
 // Create the settings overlay
 const settingsOverlay = new SettingsOverlay(container);


### PR DESCRIPTION
**This enables the extension side to reload the current editor state when the user accidentally closes the editor.**

VSCode does not allow an extension to prevent the user from closing a webview (a window in VSCode, where our editor is rendered). They only allow you to add a listener for "onDidDispose", which gets fired *after* the webview has already been closed.
There is thus no way to sync the ProofFlow document just before shutdown, neither from the editor side nor from the extension side, since no communication is possible after the webview has been closed.

As a workaround, this PR:

- Checks whether we are in a VSCode environment, and if we are
- Syncs the ProofFlow document with VSCode every second by posting a message to the webview.

From the extension side this message is being listened for and the current pf document is being saved to a local variable.
After the webview is closed the user gets prompted if he was sure he wanted to close it, and if he is not the webview gets re-opened with the last synced state (by sending a "loadFile" message from the webview to the editor, which then parses that message and calls ProofFlow's "openFile").