### PR TITLE
FIX some verso parsing stuff

### DIFF
--- a/src/ProofFlow/parser/outputconfigs.ts
+++ b/src/ProofFlow/parser/outputconfigs.ts
@@ -26,7 +26,7 @@ const LeanOutput: OutputConfig = {
   math: ["\n:::math\n", "\n:::\n"],
   collapsible: ["\n:::collapsible\n", "\n:::\n"],
   collapsibletitle: ["\n:::collapsible\n#TITLE\n", "\n:::\n"],
-  input: ["\n:::input\n", "\n:::\n"],
+  input: ["\n:::input\n.\n", "\n:::\n"],
 };
 
 const PureLeanOutput: OutputConfig = {

--- a/src/ProofFlow/parser/parsers.ts
+++ b/src/ProofFlow/parser/parsers.ts
@@ -23,7 +23,7 @@ const LeanParser = new SimpleParser({
   code: [/\n```lean\n/, /\n```\n/],
   math: [/\n:::math\n/, /\n:::\n/],
   collapsible: [/\n:::collapsible\n(?:#(.*?)\n)?/, /\n:::\n/],
-  input: [/\n:::input\n/, /\n:::\n/],
+  input: [/\n:::input\n\.\n/, /\n:::\n/],
 });
 
 const PureLeanParser = new SimpleParser({

--- a/verso-genre/VersoProofFlow/Demo.lean
+++ b/verso-genre/VersoProofFlow/Demo.lean
@@ -17,8 +17,13 @@ def wrongfive : Nat := 6
 
 :::
 # Correct Proof
+:::input
+.
+
 ```lean
 -- Prove that five equals 5
 theorem five_eq_5 : five = 5 := by
   rfl
 ```
+
+:::


### PR DESCRIPTION
This adds a funky `.` to the parsing, its a workaround for a strange error that happens when an input area fully encapsulates some other area and nothing else