### PR TITLE
ADD: saving as purelean on editor open

### DIFF
--- a/src/ProofFlow/editor/ProofFlow.ts
+++ b/src/ProofFlow/editor/ProofFlow.ts
@@ -109,6 +109,7 @@ export class ProofFlow {
 
   private undoTrackStack: Node[] = [];
   private redoTrackStack: Node[] = [];
+  public hasFileOpen: boolean = false;
 
   /**
    * Represents the ProofFlow class.
@@ -363,6 +364,7 @@ export class ProofFlow {
    * @param fileType - The type of the file.
    */
   public async openFile(text: string, fileType: AcceptedFileType) {
+    this.hasFileOpen = true;
     this.fileType = fileType;
     text = text.replace(/\r/gi, ""); // Windows uses Carriage feeds but we don't like that.
 
@@ -651,6 +653,8 @@ export class ProofFlow {
     this.lspClient?.shutdown();
     this.lspClient = undefined;
 
+    this.hasFileOpen = false;
+
     this.minimap?.destroy();
     this.removeGlobalKeyBindings();
 
@@ -817,6 +821,15 @@ export class ProofFlow {
       redo(this.editorView.state, this.editorView.dispatch);
       this.addRedoTrack();
     }
+  }
+
+  /**
+   * Sets the outputConfig of the pfDocument
+   * @param outputConfig the output config
+   */
+  public setOutputConfig(outputConfig: OutputConfig) {
+    this.pfDocument.outputConfig = outputConfig;
+    this.outputConfig = outputConfig;
   }
 
   /**

--- a/src/ProofFlow/parser/parsers.ts
+++ b/src/ProofFlow/parser/parsers.ts
@@ -28,7 +28,7 @@ const LeanParser = new SimpleParser({
 
 const PureLeanParser = new SimpleParser({
   text: [/\n\/-\n/, /\n-\/\n/],
-  math: [/\n\/-\$\$\n/, /\n-\/\$\$\n/],
+  math: [/\n\/-\$\$\n/, /\n\$\$-\/\n/],
   collapsible: [/\n-- <hint(?: title="(.*?)")?>\n?/, /\n-- <\/hint>\n/],
   input: [/\n-- <input-area>\n/, /\n-- <\/input-area>\n/],
 });

--- a/src/ProofFlow/settings/settings.ts
+++ b/src/ProofFlow/settings/settings.ts
@@ -1,4 +1,5 @@
 import { proofFlow } from "../../main";
+import { CoqMDOutput, LeanOutput, PureLeanOutput } from "../parser/outputconfigs";
 import { updateColors } from "./updateColors";
 import { colorSchemesKeys } from "./updateColors";
 
@@ -337,6 +338,20 @@ export class SettingsOverlay {
     lspButton.addEventListener("click", () => {
       console.log("LSP Path: " + lspPath.value); //TODO Add lspPath functionality
       // proofFlow.setLspPath(lspPath.value);
+      if (!proofFlow.hasFileOpen) {
+        switch (lspSelect.value) {
+          case "lean":
+            proofFlow.setOutputConfig(PureLeanOutput);
+            proofFlow.fileName = "file.lean";
+            break;
+          case "coq":
+            proofFlow.setOutputConfig(CoqMDOutput);
+            proofFlow.fileName = "file.mv";
+            break;
+          default:
+            break;
+        }
+      }
       let lsp = {
         path: lspPath.value,
         type: lspSelect.value,


### PR DESCRIPTION
If you select coq in the settings and click apply, it will save as .mv.
If you select lean in the settings and click apply, it will save as .lean.

By default it will save as .mv

This functionality should be disabled the moment you open a file.

Also this fixes a bug in the pureleanparser, it was ill defined